### PR TITLE
Remove gamma correction from color correction shader

### DIFF
--- a/services/surfaceflinger/RenderEngine/ProgramCache.cpp
+++ b/services/surfaceflinger/RenderEngine/ProgramCache.cpp
@@ -237,10 +237,8 @@ String8 ProgramCache::generateFragmentShader(const Key& needs) {
             // un-premultiply if needed before linearization
             fs << "gl_FragColor.rgb = gl_FragColor.rgb/gl_FragColor.a;";
         }
-        fs << "gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(2.2));";
         fs << "vec4 transformed = colorMatrix * vec4(gl_FragColor.rgb, 1);";
         fs << "gl_FragColor.rgb = transformed.rgb/transformed.a;";
-        fs << "gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(1.0 / 2.2));";
         if (!needs.isOpaque() && needs.isPremultiplied()) {
             // and re-premultiply if needed after gamma correction
             fs << "gl_FragColor.rgb = gl_FragColor.rgb*gl_FragColor.a;";


### PR DESCRIPTION
Gamma correction was incorrectly skewing both color inversion and
Daltonization, which resulted in washed-out colors.

Bug: 20346301
Change-Id: I34d879f902c3be115b2d23f09c3ed3902799759e
(cherry picked from commit 3acd9f1d8fdffc0ed0837ebbabcac0c4014015b3)
